### PR TITLE
Add support for running on a partial event size.

### DIFF
--- a/PlotFromRoot.py
+++ b/PlotFromRoot.py
@@ -1,6 +1,8 @@
 import ROOT
 import argparse
 
+from functools import partial
+
 from analysis import config
 from analysis import Sample
 from analysis import ExampleAnalysis
@@ -46,7 +48,7 @@ def plot_and_save(*args):
         # Save the canvas as a PNG file
         canvas.SaveAs(f'{hname}.png')
 
-def main(runconfig_path):
+def main(runconfig_path, nevents=-1):
     """
     Main function to read tree contents, create distributions, and plot/save 
     the histograms.
@@ -72,7 +74,7 @@ def main(runconfig_path):
 
     analysis=ExampleAnalysis.ExampleAnalysis()
 
-    hists=map(analysis.run, samples)
+    hists=map(partial(analysis.run, nevents=nevents), samples)
 
     plot_and_save(*list(hists))
 
@@ -80,6 +82,7 @@ if __name__ == "__main__":
     # Set up argument parser
     parser = argparse.ArgumentParser(description="script that reads root files to create and plot distributions.")
     parser.add_argument("runconfig", type=str, help="Path to the run configuration YAML file.")
+    parser.add_argument("-n", "--nevents", type=int, default=-1, help="Maximum number of events to process per sample..")
 
     ROOT.gInterpreter.AddIncludePath(f"{config.mg5amcnlo}/Delphes");
     ROOT.gInterpreter.AddIncludePath(f"{config.mg5amcnlo}/Delphes/external");
@@ -90,4 +93,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Execute the main function with the provided arguments
-    main(args.runconfig)
+    main(args.runconfig, nevents=args.nevents)

--- a/analysis/Analysis.py
+++ b/analysis/Analysis.py
@@ -56,14 +56,26 @@ class Analysis:
         """
         return True
 
-    def run(self, sample):
+    def run(self, sample, nevents=-1):
         """
         Runs the analysis.
+
+        Parameters
+        ----------
+        sample : Analysis.Sample
+            A sample object with the currently loaded event.
+        nevents : int
+            Maximum number of events to run over. -1 means all.
         """
         histograms = self.histogrammer(sample.title, sample.style)
         histograms.create_histograms()
 
-        for idx in range(sample.reader.GetEntries()):
+        # Calculate the requested number of events
+        nevents=nevents if nevents>=0 else sample.reader.GetEntries()
+        nevents=min(sample.reader.GetEntries(),nevents)
+
+        # Loop!
+        for idx in range(nevents):
             sample.reader.ReadEntry(idx)
 
             if not self.selection(sample):
@@ -76,6 +88,6 @@ class Analysis:
             attr=getattr(histograms, attrname)
             if not isinstance(attr,ROOT.TH1):
                 continue # not a histogram
-            attr.Scale(1./sample.reader.GetEntries())
+            attr.Scale(1./nevents)
 
         return histograms


### PR DESCRIPTION
Adds an option `-n`/`--nevents` to run over the specified number of events instead of all the events in the input files. This is useful when debugging code without waiting for full statistics.

The `Analysis.run` function now takes an extra argument of `nevents` to propagate this request. The default value of `-1` means to process all available events. The normalization is correctly accounted for.