### PR TITLE
Add support for configurable datadir.

### DIFF
--- a/PlotFromRoot.py
+++ b/PlotFromRoot.py
@@ -65,8 +65,8 @@ def main(runconfig_path):
 
         for p in path:
             # Relative paths should be relative to datadir
-            if not path.startswith('/'):
-                path=f'{config.datadir}/{path}'
+            if not p.startswith('/'):
+                p=f'{config.datadir}/{p}'
             # Add file to the sample
             sample.add_file(p)
         sample.style=input.get('style', {})

--- a/PlotFromRoot.py
+++ b/PlotFromRoot.py
@@ -64,6 +64,10 @@ def main(runconfig_path):
             path=[path]
 
         for p in path:
+            # Relative paths should be relative to datadir
+            if not path.startswith('/'):
+                path=f'{config.datadir}/{path}'
+            # Add file to the sample
             sample.add_file(p)
         sample.style=input.get('style', {})
         sample.open()

--- a/analysis.yaml.example
+++ b/analysis.yaml.example
@@ -1,1 +1,2 @@
 mg5amcnlo: /home/kkrizka/Sources/mg5amcnlo
+datadir: /disk/moose/general/FutureWMass/samples

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,5 +1,6 @@
 from kkconfig import local
 
 mg5amcnlo = '/home/kkrizka/Sources/mg5amcnlo'
+datadir = '/disk/moose/general/FutureWMass/samples'
 
 local.load_settings('.analysis.yaml', globals())


### PR DESCRIPTION
Add a `datadir` option to the local configuration. It will be appended to any relative path (path not starting with a `/`) in a runconfig filelist.