### PR TITLE
Add support for ratio plots.

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -1,3 +1,9 @@
+ratio:
+  reference: 1
+  yaxis:
+    min: 0.9
+    max: 1.1
+    title: ratio
 inputs:
   - path: /disk/moose/general/FutureWMass/samples/uC_ww_leplep_sqrts10000_mw78900.root
     title: 78.9 GeV

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,4 @@ packages =
 	 analysis
 install_requires =
 	 kkconfig
-	 kkroot
+	 kkroot>=0.0.2


### PR DESCRIPTION
Ratio plots can now be added by adding the `ratio` entry to the run config. If present, the canvas is split into two and the ratio with respect to the specified reference is draw in the lower pad. If the `ratio` entry is not present, then only a single pad with the histograms is drawn.

An example of specifying the ratio plot in run config (also added to `example.yaml`):

```yaml
ratio:
  reference: 1
  yaxis:
    min: 0.9
    max: 1.1
    title: ratio
```

The following keys are used:
- `reference`: The index of the input file inside `inputs` to be used as the denominator when plotting the ratio.
- `yaxis`: Specification for the y-axis in the ratio pad. The `min` and `max` specify the axis range. The remaining elements are applied as a style to the `TAxis` object (see [available style keys](https://github.com/kkrizka/kkroot/blob/67e4615aa6609badbef3a12e1d72a3fc2babbffb/kkroot/style.py#L82)).

This requires update to [kkroot v0.0.2](https://github.com/kkrizka/kkroot/releases/tag/v0.0.2).