### PR TITLE
Add support for TH2.

### DIFF
--- a/analysis/ExampleAnalysis.py
+++ b/analysis/ExampleAnalysis.py
@@ -8,9 +8,13 @@ class ExampleHistograms(Analysis.Histograms):
 
         self.hist_dimuonPt=ROOT.TH1F("dimuon_pt", f'{self.title};di-muon p_{{T}} [GeV];a.u.', 50, 0, 5000)
 
+        self.hist_muon1Ptvsmuon0Pt=ROOT.TH2F("muon1vsmuon0_pt", f'{self.title};leading muon p_{{T}} [GeV];subleading muon p_{{T}} [GeV];', 50, 0, 5000, 50, 0, 5000)
+
     def fill_histograms(self, sample):
         self.hist_muon0Pt.Fill(sample.Muon[0].PT)
         self.hist_muon1Pt.Fill(sample.Muon[1].PT)
+
+        self.hist_muon1Ptvsmuon0Pt.Fill(sample.Muon[0].PT,sample.Muon[1].PT)
 
         # Add muons using pT
         dimuon=sample.Muon[0].P4()+sample.Muon[1].P4()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Reading-from-Delphes
-version = 0.0.1
+version = 0.1.0
 url = https://github.com/BILPAware/FutureWMassAnalysis
 description = Simple script to make plots using the ExRootAnalysis output from Delphes
 long_description = file: README.md


### PR DESCRIPTION
2D histograms added to a `Analysis.Histograms` as `TH2` can now be plotted. A single file is created per histogram and sample with the name `{histname}_{sample.title}.png`.