### PR TITLE
Fix legend position in the top right corner.

### DIFF
--- a/PlotFromRoot.py
+++ b/PlotFromRoot.py
@@ -13,7 +13,7 @@ from kkroot import style
 from kkroot import canvas
 
 def plot_and_save_TH1(hname, *args, ratio=None):
-"""
+    """
     Plot and save 1D histograms.
 
     The histograms of all samples are added to a single
@@ -56,7 +56,7 @@ def plot_and_save_TH1(hname, *args, ratio=None):
     hs.Draw("nostack")
     hs.GetXaxis().SetTitle(exhist.GetXaxis().GetTitle())
     hs.GetYaxis().SetTitle(exhist.GetYaxis().GetTitle())
-    pad.BuildLegend()
+    pad.BuildLegend(0.6,0.95-0.07*len(args),0.95,0.95)
     pad.Update()
 
     # Draw ratio (if requested)


### PR DESCRIPTION
The legend position is now fix in the top right corner. This was prevent issues with automatic placement in certain cases where the legend overlapped with the histograms.

The legend position is now `0.6,0.95-0.07*nSamples,0.95,0.95`. Each row is 7% of the height.

Also hidden a fix for a syntax error introduced in #7 .