### PR TITLE
Draft: Example pseudodata generation.

### DIFF
--- a/Run_Chi2test.py
+++ b/Run_Chi2test.py
@@ -27,16 +27,22 @@ file = ROOT.TFile.Open(root_file_name)
 print(f"Nominal is hist_{distribution_for_test}_{nominal_hist_name}")
 nominal_hist = file.Get(f"hist_{distribution_for_test}_{nominal_hist_name}")
 
-# Check if the nominal histogram exists                                                                                                                                                       
+# Check if the nominal histogram exists
 if not nominal_hist:
     print(f"Nominal histogram '{nominal_hist_name}' not found in file")
     exit(1)
+
+# Generate pseudodata using the expected values
+pseudodata_hist = nominal_hist.Clone()
+pseudodata_hist.Reset()
+print(nominal_hist)
+pseudodata_hist.FillRandom(nominal_hist, 10_000_000) # Fixed cross-section of 10 ab-1
 
 # Open CSV file for writing
 with open(output_csv, 'w', newline='') as csvfile:
     csvwriter = csv.writer(csvfile)
     # Write CSV header
-    csvwriter.writerow(['W mass', 'Chi2'])
+    csvwriter.writerow(['Wmass', 'Chi2',' Pvalue'])
     
     # Loop over all histograms you want to compare nominal to
     for hist_name in histograms_to_compare:
@@ -46,12 +52,12 @@ with open(output_csv, 'w', newline='') as csvfile:
             print(f" Histogram 'hist_{distribution_for_test}_{hist_name}' not found in file")
             continue
          
-        chi2 = nominal_hist.Chi2Test(hist, "WW NORM CHI2")
-        p_value = nominal_hist.Chi2Test(hist, "WW NORM P")
+        chi2 = pseudodata_hist.Chi2Test(hist, "UW CHI2")
+        p_value = pseudodata_hist.Chi2Test(hist, "UW P")
         
-        csvwriter.writerow([hist_name, chi2])
+        csvwriter.writerow([hist_name, chi2, p_value])
         # Print results                                                                                                                                                                       
-        print(f"Comparing nominal histogram (hist_{distribution_for_test}_{nominal_hist_name}) with 'hist_{distribution_for_test}_{hist_name}':")
+        print(f"Comparing pseudodata histogram (hist_{distribution_for_test}_{nominal_hist_name}) with 'hist_{distribution_for_test}_{hist_name}':")
         print(f"Chi2: {chi2}")
         print(f"p-value: {p_value}")
         


### PR DESCRIPTION
Example of how to generate pseudodata for a given luminosity inside the chi2test script.

The nominal histogram is used to generate pseudodata using the `TH1::FillRandom` events. The number of requested events is the nominal histogram integral (cross-section) multiplied by 10 ab-1 (FCCee luminosity).

The `Chi2Test` options have been updated for unweighted (pseudodata) to weighted (template) fit.

Just an example for discussion. Not mean to be merged. If we do want it merged, the following needs to be done
 - [ ] Decide if we generate pseudodata here or in an external script.
 - [ ] Configurable luminosity. Currently fixed to FCCee.